### PR TITLE
Added 3xx and a few other statuses support & updated output

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ go run main.go urls2.txt
 `go run main.go *.txt`
 
 - colorfull outputs
-bad URLs in red, good URLs in green, unknown URLs in gray
+bad URLs in red, good URLs in green, unknown URLs in gray, redirect URLS in yellow,
 
 - support parallelization using go routine
 

--- a/main.go
+++ b/main.go
@@ -38,6 +38,14 @@ func checkStatus(link string, wg *sync.WaitGroup) {
 	switch resp.StatusCode {
 	case 200:
 		color.Green.Println(resp.StatusCode, link, "is alive")
+	case 300:
+		color.Yellow.Println(resp.StatusCode, link, "it's alive, multiple choices")
+	case 301:
+		color.Yellow.Println(resp.StatusCode, link, "it's alive, moved permanently")
+	case 307:
+		color.Yellow.Println(resp.StatusCode, link, "it's alive, found but its a temporary redirect")
+	case 308:
+		color.Yellow.Println(resp.StatusCode, link, "it's alive, permanent redirect")
 	case 400, 404:
 		color.Red.Println(resp.StatusCode, link, "is bad")
 	default:

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func removeDuplicate(urls []string) []string {
 
 func checkStatus(link string, wg *sync.WaitGroup) {
 	defer wg.Done()
+
 	client := http.Client{
 		Timeout: 5 * time.Second,
 	}
@@ -37,17 +38,29 @@ func checkStatus(link string, wg *sync.WaitGroup) {
 	}
 	switch resp.StatusCode {
 	case 200:
-		color.Green.Println(resp.StatusCode, link, "is alive")
+		color.Green.Println(resp.StatusCode, link, "is alive, [OK]")
 	case 300:
-		color.Yellow.Println(resp.StatusCode, link, "it's alive, multiple choices")
+		color.Yellow.Println(resp.StatusCode, link, "it's alive, [Multiple Choices]")
 	case 301:
-		color.Yellow.Println(resp.StatusCode, link, "it's alive, moved permanently")
+		color.Yellow.Println(resp.StatusCode, link, "it's alive, [Found but its moved permanently]")
 	case 307:
-		color.Yellow.Println(resp.StatusCode, link, "it's alive, found but its a temporary redirect")
+		color.Yellow.Println(resp.StatusCode, link, "it's alive, [Found but its a temporary redirect]")
 	case 308:
-		color.Yellow.Println(resp.StatusCode, link, "it's alive, permanent redirect")
-	case 400, 404:
-		color.Red.Println(resp.StatusCode, link, "is bad")
+		color.Yellow.Println(resp.StatusCode, link, "it's alive, [Found but its a permanent redirect]")
+	case 400:
+		color.Red.Println(resp.StatusCode, link, "is bad, [Bad Request]")
+	case 401:
+		color.Red.Println(resp.StatusCode, link, "is bad, [Unauthorized]")
+	case 402:
+		color.Red.Println(resp.StatusCode, link, "is bad, [Payment Required]")
+	case 403:
+		color.Red.Println(resp.StatusCode, link, "is bad, [Forbidden]")
+	case 404:
+		color.Red.Println(resp.StatusCode, link, "is bad, [Not Found]")
+	case 410:
+		color.Red.Println(resp.StatusCode, link, "is bad, [Gone]")
+	case 500:
+		color.Red.Println(resp.StatusCode, link, "is bad, [Internal Server Error]")
 	default:
 		color.Gray.Println(resp.StatusCode, link, "is unknown")
 	}

--- a/urls2.txt
+++ b/urls2.txt
@@ -1,2 +1,3 @@
 http://google.ca
 http://google.com
+https://httpstat.us/300


### PR DESCRIPTION
Alright so GO has redirect support by default so the request and response set up hasn't changed. What I did change though was adding more common status codes to the list then you had before and labeling them with the error types. Small update to readme by adding 3xx status codes are displayed in "yellow". Added a test url to url2.txt for testing the status code of 300. One thing to note is you currently have the timeout setting to 5 seconds, redirects typically get hanged up for more then that, so if you wanted to display most redirects you would have to increase this timer.